### PR TITLE
added support for node18+

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.8.4",
   "private": true,
   "scripts": {
-    "start": "react-native start",
-    "ios": "react-native run-ios",
-    "android": "react-native run-android",
+    "start": "SET NODE_OPTIONS=--openssl-legacy-provider && react-native start",
+    "ios": "SET NODE_OPTIONS=--openssl-legacy-provider && react-native run-ios",
+    "android": "SET NODE_OPTIONS=--openssl-legacy-provider && react-native run-android",
     "test:e2e": "detox test -c ios.sim.debug",
     "build:e2e": "detox build -c ios.sim.debug",
     "ci:test:e2e": "detox test -c ios.sim.release -l verbose --cleanup",


### PR DESCRIPTION
SET NODE_OPTIONS=--openssl-legacy-provider
to solve the error below:
Error: error:0308010C:digital envelope routines::unsupported